### PR TITLE
Refactor connection cleanup in integration tests

### DIFF
--- a/test-integration/src/test/java/lan/tlab/r4j/integration/sql/dsl/DeleteBuilderIntegrationTest.java
+++ b/test-integration/src/test/java/lan/tlab/r4j/integration/sql/dsl/DeleteBuilderIntegrationTest.java
@@ -27,9 +27,7 @@ class DeleteBuilderIntegrationTest {
 
     @AfterEach
     void tearDown() throws SQLException {
-        if (connection != null && !connection.isClosed()) {
-            connection.close();
-        }
+        TestDatabaseUtil.closeConnection(connection);
     }
 
     @Test

--- a/test-integration/src/test/java/lan/tlab/r4j/integration/sql/dsl/InsertBuilderIntegrationTest.java
+++ b/test-integration/src/test/java/lan/tlab/r4j/integration/sql/dsl/InsertBuilderIntegrationTest.java
@@ -28,9 +28,7 @@ class InsertBuilderIntegrationTest {
 
     @AfterEach
     void tearDown() throws SQLException {
-        if (connection != null && !connection.isClosed()) {
-            connection.close();
-        }
+        TestDatabaseUtil.closeConnection(connection);
     }
 
     @Test

--- a/test-integration/src/test/java/lan/tlab/r4j/integration/sql/dsl/SelectBuilderIntegrationTest.java
+++ b/test-integration/src/test/java/lan/tlab/r4j/integration/sql/dsl/SelectBuilderIntegrationTest.java
@@ -26,9 +26,7 @@ class SelectBuilderIntegrationTest {
 
     @AfterEach
     void tearDown() throws SQLException {
-        if (connection != null && !connection.isClosed()) {
-            connection.close();
-        }
+        TestDatabaseUtil.closeConnection(connection);
     }
 
     @Test

--- a/test-integration/src/test/java/lan/tlab/r4j/integration/sql/dsl/UpdateBuilderIntegrationTest.java
+++ b/test-integration/src/test/java/lan/tlab/r4j/integration/sql/dsl/UpdateBuilderIntegrationTest.java
@@ -27,9 +27,7 @@ class UpdateBuilderIntegrationTest {
 
     @AfterEach
     void tearDown() throws SQLException {
-        if (connection != null && !connection.isClosed()) {
-            connection.close();
-        }
+        TestDatabaseUtil.closeConnection(connection);
     }
 
     @Test

--- a/test-integration/src/test/java/lan/tlab/r4j/integration/sql/util/TestDatabaseUtil.java
+++ b/test-integration/src/test/java/lan/tlab/r4j/integration/sql/util/TestDatabaseUtil.java
@@ -69,4 +69,16 @@ public final class TestDatabaseUtil {
                     "INSERT INTO users VALUES (4, 'Alice', 'alice@example.com', 35, true, '1990-01-01', '2023-01-01')");
         }
     }
+
+    /**
+     * Closes the database connection if it is not null and not already closed.
+     *
+     * @param connection the database connection to close
+     * @throws SQLException if closing the connection fails
+     */
+    public static void closeConnection(Connection connection) throws SQLException {
+        if (connection != null && !connection.isClosed()) {
+            connection.close();
+        }
+    }
 }


### PR DESCRIPTION
Streamline connection cleanup in integration tests by utilizing the `closeConnection` method from `TestDatabaseUtil`. This enhances code readability and maintainability.