### PR TITLE
AssertJ has XML External Entity (XXE) vulnerability when parsing untrusted XML via isXmlEqualTo assertion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <dep.testcontainer-core.version>2.0.3</dep.testcontainer-core.version>
     <dep.testcontainer.version>1.21.4</dep.testcontainer.version>
     <dep.junit-jupiter.version>6.0.1</dep.junit-jupiter.version>
-    <dep.assertj-core.version>3.27.6</dep.assertj-core.version>
+    <dep.assertj-core.version>3.27.7</dep.assertj-core.version>
     <dep.mockito-core.version>5.21.0</dep.mockito-core.version>
     <dep.byte-buddy.version>1.18.5</dep.byte-buddy.version>
 


### PR DESCRIPTION


An XML External Entity (XXE) vulnerability exists in org.assertj.core.util.xml.XmlStringPrettyFormatter: the toXmlDocument(String) method initializes DocumentBuilderFactory with default settings, without disabling DTDs or external entities. This formatter is used by the isXmlEqualTo(CharSequence) assertion for CharSequence values.

An application is vulnerable only when it uses untrusted XML input with one of the following methods:

    isXmlEqualTo(CharSequence) from org.assertj.core.api.AbstractCharSequenceAssert
    xmlPrettyFormat(String) from org.assertj.core.util.xml.XmlStringPrettyFormatter

Impact

If untrusted XML input is processed by the methods mentioned above (e.g., in test environments handling external fixture files), an attacker could:

    Read arbitrary local files via file:// URIs (e.g., /etc/passwd, application configuration files)
    Perform Server-Side Request Forgery (SSRF) via HTTP/HTTPS URIs
    Cause Denial of Service via "Billion Laughs" entity expansion attacks

Mitigation

isXmlEqualTo(CharSequence) has been deprecated in favor of XMLUnit in version 3.18.0 and will be removed in version 4.0. Users of affected versions should, in order of preference:

    Replace isXmlEqualTo(CharSequence) with XMLUnit, or
    Upgrade to version 3.27.7, or
    Avoid using isXmlEqualTo(CharSequence) or XmlStringPrettyFormatter with untrusted input.

XmlStringPrettyFormatter has historically been considered a utility for isXmlEqualTo(CharSequence) rather than a feature for AssertJ users, so it is deprecated in version 3.27.7 and removed in version 4.0, with no replacement.
References

    CWE-611: Improper Restriction of XML External Entity Reference
    OWASP XXE Prevention Cheat Sheet

